### PR TITLE
fix(#59): 1v1 게임에서만 사용자 프로필 업데이트

### DIFF
--- a/srcs/backend/srcs/game/views.py
+++ b/srcs/backend/srcs/game/views.py
@@ -74,7 +74,7 @@ class RouteGameView(APIView):
             }
         )
 
-        if response.status_code == 201:
+        if response.status_code == 201 and game_path == "/game/me/1v1s/":
             user_manager_scheme = request.scheme
             user_manager_port = env("USER_MANAGER_PORT")
             user_manager_path = "/users/me/profile/"


### PR DESCRIPTION
## 📌 연관된 이슈
- #59 

## 📝 작업 내용
- 토너먼트 전적 추가 시에는 승패 업데이트 막음

## 🌳 작업 브랜치명
- `feat/update-profile`