### PR TITLE
feat(#18): 모든 컨테이너에 ssl 적용

### DIFF
--- a/srcs/backend/Dockerfile
+++ b/srcs/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-alpine
 RUN mkdir -p /var/www/django
 
 ARG SSL_PATH=/etc/ssl/private
-ARG DOMAIN=domain
+ARG DOMAIN=fresh_pong
 
 #set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/srcs/backend/srcs/backend/settings.py
+++ b/srcs/backend/srcs/backend/settings.py
@@ -82,7 +82,7 @@ REST_FRAMEWORK = {
 
 # 추가적인 JWT_AUTH 설정, https://django-rest-framework-simplejwt.readthedocs.io/en/latest/
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
 
     "ROTATE_REFRESH_TOKENS": True,  # True로 설정할 경우, refresh token을 보내면 새로운 access token과 refresh token이 반환된다.

--- a/srcs/backend/srcs/game/views.py
+++ b/srcs/backend/srcs/game/views.py
@@ -4,7 +4,7 @@ import requests
 import environ
 from django.http import HttpResponse, JsonResponse
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.views import APIView
 
@@ -15,11 +15,8 @@ USER_MANAGER_HOST_NAME = "user-manager"
 
 
 class RouteGameView(APIView):
-    permission_classes = [AllowAny]
-
-    # TODO: replace with below
-    # permission_classes = [IsAuthenticated]
-    # authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [JWTAuthentication]
 
     def get(self, request):
         token = request.headers.get("Authorization")

--- a/srcs/backend/srcs/users/views.py
+++ b/srcs/backend/srcs/users/views.py
@@ -2,7 +2,7 @@ import requests
 import environ
 from django.http import HttpResponse, JsonResponse
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.views import APIView
 
@@ -12,11 +12,8 @@ USER_MANAGER_HOST_NAME = "user-manager"
 
 
 class RouteToUserManagerAPIView(APIView):
-    permission_classes = [AllowAny]
-
-    # TODO: replace with below
-    # permission_classes = [IsAuthenticated]
-    # authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [JWTAuthentication]
 
     def get(self, request):
         token = request.headers.get("Authorization")

--- a/srcs/backend/tools/run_backend.sh
+++ b/srcs/backend/tools/run_backend.sh
@@ -30,5 +30,5 @@ python manage.py migrate
 python manage.py createsuperuser --no-input
 
 # todo ssl 가장 나중에 하자. 그리고 오류 생김. sslserver 구동할 수 있게 패키지 받아야 함. django settings에 INSTALLED_APP에도 설정 해야 함.
-python manage.py runsslserver --certificate /etc/ssl/private/domain.crt --key /etc/ssl/private/domain.key 0:8000
+python manage.py runsslserver --certificate /etc/ssl/private/fresh_pong.crt --key /etc/ssl/private/fresh_pong.key 0:8000
 # python manage.py runserver 0:8000

--- a/srcs/game/Dockerfile
+++ b/srcs/game/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-alpine
 
 RUN mkdir -p /var/www/django
 
-ARG DOMAIN=domain
+ARG DOMAIN=fresh_pong
 ARG SSL_PATH=/etc/ssl/private
 
 #set environment variables

--- a/srcs/game/srcs/game/settings.py
+++ b/srcs/game/srcs/game/settings.py
@@ -50,6 +50,9 @@ INSTALLED_APPS = [
 ]
 
 REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.AllowAny',
+    ),
     'DATETIME_FORMAT': "%Y/%m/%d %H:%M:%S",
     'DATETIME_INPUT_FORMATS': ["%Y/%m/%d %H:%M:%S"],
 }

--- a/srcs/game/srcs/records/views.py
+++ b/srcs/game/srcs/records/views.py
@@ -38,7 +38,7 @@ class MyOneOnOneGameAPIView(generics.ListCreateAPIView):
         payload = jwt.decode(jwt=token, key=env("SECRET_KEY"), algorithms=['HS256'])
 
         me = payload.get("user_id")
-        queryset = Game.objects.filter(player_one=me, player_two="guest", type='1v1')
+        queryset = Game.objects.filter(player_one=me, player_two="guest", type='1v1').order_by("time")
 
         return queryset
 

--- a/srcs/game/tools/run_game.sh
+++ b/srcs/game/tools/run_game.sh
@@ -18,4 +18,4 @@ python manage.py migrate
 
 python add_game.py
 
-python manage.py runsslserver --certificate /etc/ssl/private/domain.crt --key /etc/ssl/private/domain.key 0:${GAME_PORT}
+python manage.py runsslserver --certificate /etc/ssl/private/fresh_pong.crt --key /etc/ssl/private/fresh_pong.key 0:${GAME_PORT}

--- a/srcs/user-manager/Dockerfile
+++ b/srcs/user-manager/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-alpine
 
 RUN mkdir -p /var/www/django
 
-ARG DOMAIN=domain
+ARG DOMAIN=fresh_pong
 ARG SSL_PATH=/etc/ssl/private
 
 #set environment variables

--- a/srcs/user-manager/srcs/users/models.py
+++ b/srcs/user-manager/srcs/users/models.py
@@ -14,7 +14,7 @@ class User(models.Model):
 
     username = models.CharField(max_length=10, unique=True)
     avatar = models.BinaryField(default=get_default_avatar('static/avatar.jpg'))
-    status = models.CharField(max_length=7, choices=STATUS_CHOICES, default='ONLINE')
+    status = models.CharField(max_length=7, choices=STATUS_CHOICES, default='OFFLINE')
     message = models.TextField(blank=True, default='')
     wins = models.IntegerField(default=0)
     loses = models.IntegerField(default=0)

--- a/srcs/user-manager/tools/run_user_manager.sh
+++ b/srcs/user-manager/tools/run_user_manager.sh
@@ -21,4 +21,4 @@ python manage.py migrate
 
 python add_user.py
 
-python manage.py runsslserver --certificate /etc/ssl/private/domain.crt --key /etc/ssl/private/domain.key 0:${USERS_PORT}
+python manage.py runsslserver --certificate /etc/ssl/private/fresh_pong.crt --key /etc/ssl/private/fresh_pong.key 0:${USERS_PORT}


### PR DESCRIPTION
## 📌 연관된 이슈
- #18 

## 📝 작업 내용
- `user-manager`, `game` 컨테이너에도 ssl 적용
- jwt 인증 옵션 살리기
- access token 만료기간 5분으로 단축
- 기본 user 상태 `OFFLINE`으로 변경

## 🌳 작업 브랜치명
- `refactor/set_sslserver`

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요